### PR TITLE
게시판 정규화 수정

### DIFF
--- a/db/query.json
+++ b/db/query.json
@@ -13,12 +13,12 @@
         "insert": "INSERT INTO tb_tutor(`id`) VALUES (?)"
     },
     "freeBoard": {
-        "insert": "INSERT INTO tb_free_board (`user_id`, `title`, `content`) VALUES (?, ?, ?)",
+        "insert": "INSERT INTO tb_free_board (`user_id`, `title`, `content`, `content_json`) VALUES (?, ?, ?, ?)",
         "update": "UPDATE tb_free_board SET `title` = ?, `content` = ?, updated_at = NOW() WHERE id = ? AND user_id = ?",
         "updateViews": "UPDATE tb_free_board SET `views` = `views` + 1 WHERE id = ?",
         "delete": "DELETE FROM tb_free_board WHERE id = ? AND user_id = ?",
-        "select": "SELECT f.id, f.user_id, f.title, f.content, f.created_at, f.views , u.name , count(l.user_id) AS like_count, count(c.id) AS comment_count FROM tb_free_board AS f LEFT JOIN tb_user AS u ON f.user_id = u.id LEFT JOIN tb_free_board_comments AS c ON f.id = c.free_board_id LEFT JOIN tb_like AS l ON f.id = l.free_board_id WHERE f.id = ? GROUP BY f.id, f.title, f.content, f.created_at, f.views, u.name",
-        "selectAll": "SELECT f.id, f.title, f.content, f.created_at, f.views , u.name , count(l.user_id) AS like_count, count(c.id) AS comment_count  FROM tb_free_board AS f LEFT JOIN tb_user AS u ON f.user_id = u.id LEFT JOIN tb_free_board_comments AS c ON f.id = c.free_board_id LEFT JOIN tb_like AS l ON f.id = l.free_board_id GROUP BY f.id, f.title, f.content, f.created_at, f.views, u.name ORDER BY f.created_at DESC LIMIT ?, ?",
+        "select": "SELECT f.id, f.user_id, f.title, f.content_json AS content, f.created_at, f.views , u.name , count(l.user_id) AS like_count, count(c.id) AS comment_count FROM tb_free_board AS f LEFT JOIN tb_user AS u ON f.user_id = u.id LEFT JOIN tb_free_board_comments AS c ON f.id = c.free_board_id LEFT JOIN tb_like AS l ON f.id = l.free_board_id WHERE f.id = ? GROUP BY f.id, f.title, f.content, f.created_at, f.views, u.name",
+        "selectAll": "SELECT f.id, f.title, f.created_at, f.views , u.name , count(l.user_id) AS like_count, count(c.id) AS comment_count  FROM tb_free_board AS f LEFT JOIN tb_user AS u ON f.user_id = u.id LEFT JOIN tb_free_board_comments AS c ON f.id = c.free_board_id LEFT JOIN tb_like AS l ON f.id = l.free_board_id GROUP BY f.id, f.title, f.content, f.created_at, f.views, u.name ORDER BY f.created_at DESC LIMIT ?, ?",
         "selectSearch": "SELECT f.id, f.title, f.created_at, f.views , u.name , count(l.user_id) AS like_count, count(c.id) AS comment_count FROM tb_free_board AS f LEFT JOIN tb_user AS u ON f.user_id = u.id LEFT JOIN tb_free_board_comments AS c ON f.id = c.free_board_id LEFT JOIN tb_like AS l ON f.id = l.free_board_id WHERE f.title LIKE ? GROUP BY f.id, f.title, f.content, f.created_at, f.views, u.name ORDER BY f.created_at DESC LIMIT ?, ?"
     },
     "freeBoardComments": {

--- a/middleware/boardParser.js
+++ b/middleware/boardParser.js
@@ -1,0 +1,27 @@
+function boardContentParser(req, res, next) {
+  const {body} = req;
+  try {
+    body.content_json = body.content;
+    body.content = textContentExtraction(body.content);
+    next();
+  }catch(e){
+    return res.status(500).json({message:e.message});
+  }
+}
+
+function textContentExtraction(content) {
+  let text= '';
+  for(const elem of content){
+    if(elem.textContent){
+      text+=elem.textContent;
+    }
+    if(Array.isArray(elem.children) && elem.children.length>0){
+      text+=` ${textContentExtraction(elem.children)}`;
+    }
+  }
+  return text;
+}
+
+module.exports = {
+  boardContentParser
+}

--- a/repository/freeBoardRepository.js
+++ b/repository/freeBoardRepository.js
@@ -5,7 +5,7 @@ async function insertFreeBoard(token, body) {
     let conn;
     try {
         conn = await connection();
-        const [row] = await conn.execute(query.freeBoard.insert, [token.id, body.title, body.content]);
+        const [row] = await conn.execute(query.freeBoard.insert, [token.id, body.title, body.content,JSON.stringify(body.content_json)]);
 
         return row;
     } catch(error) {

--- a/router/freeboard.js
+++ b/router/freeboard.js
@@ -6,7 +6,7 @@ const freeBoardComments = require("./freeBoardComments");
 
 router.get("/", freeBoardController.selectAllFreeBoard);
 
-router.post("/", authorization.reIssueToken, freeBoardController.insertFreeBoard);
+router.post("/", authorization.reIssueToken, require('../middleware/boardParser').boardContentParser,freeBoardController.insertFreeBoard);
 
 router.get("/:postId", freeBoardController.selectFreeBoard);
 

--- a/schema/freeBoard-v2.sql
+++ b/schema/freeBoard-v2.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `tb_free_board`
+ADD COLUMN `content_json` JSON NOT NULL;

--- a/schema/freeBoard.sql
+++ b/schema/freeBoard.sql
@@ -5,6 +5,6 @@ CREATE TABLE `tb_free_board` (
 	`content` MEDIUMTEXT NULL,
 	`created_at` dateTime DEFAULT CURRENT_TIMESTAMP,
 	`updated_at` dateTime DEFAULT CURRENT_TIMESTAMP,
-	`views`	INT	NULL,
+	`views`	INT	DEFAULT 0,
 	CONSTRAINT `fk_free_board_user_id` FOREIGN KEY (`user_id`) REFERENCES `tb_user` (`id`)
 );


### PR DESCRIPTION
# 추가
  - `boardParser.js` : 게시판 본문 객체 파싱 - 검색을위한 텍스트 데이터 추출
  - `freeBoard-v2.sql` : 객체 저장컬럼 추가

# 수정
  - `freeBoard.sql` - `view` 컬럼 기본값 0 : `null`로 설정되어 조회수 기능 미작동
  - `query.json`, `freeBoardRepository.js`
    - 컬럼 추가에따른 수정사항 적용